### PR TITLE
[fix]:Socket search 빈 string 버그 해결

### DIFF
--- a/SocketService/src/main/java/com/kusitms/socketservice/domain/search/controller/SearchController.java
+++ b/SocketService/src/main/java/com/kusitms/socketservice/domain/search/controller/SearchController.java
@@ -23,10 +23,4 @@ public class SearchController {
         final SearchResultResponseDto responseDto = searchService.getSearchResult(sessionId, searchRequestDto);
         template.convertAndSend("/sub/search/" + sessionId, MessageSuccessResponse.of(MessageSuccessCode.SEARCH, responseDto));
     }
-
-//    @MessageExceptionHandler
-//    public String handleException(BusinessException exception, MessageRequestDto messageRequestDto) {
-//        return exception.getErrorCode().getMessage();
-////        template.convertAndSend("/sub/meeting/" + messageRequestDto.getMeetingId(), exception.getErrorCode().getMessage());
-//    }
 }

--- a/SocketService/src/main/java/com/kusitms/socketservice/domain/search/repository/SearchRepository.java
+++ b/SocketService/src/main/java/com/kusitms/socketservice/domain/search/repository/SearchRepository.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface SearchRepository {
     List<SearchUserTemplate> findAllBySearchText(String searchText, String userId);
+
+    List<SearchUserTemplate> findAllByUserId(String userId);
 }

--- a/SocketService/src/main/java/com/kusitms/socketservice/domain/search/service/SearchService.java
+++ b/SocketService/src/main/java/com/kusitms/socketservice/domain/search/service/SearchService.java
@@ -9,17 +9,26 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Service
 public class SearchService {
     private final SearchRepository searchRepository;
+    private final static String EMPTY_STRING = "";
 
     public SearchResultResponseDto getSearchResult(Long userId, SearchRequestDto searchRequestDto) {
         List<SearchUserTemplate> searchUserTemplateList
-                = searchRepository.findAllBySearchText(searchRequestDto.getSearchText(), userId.toString());
+                = getSearchResult(searchRequestDto.getSearchText(), userId.toString());
         List<SearchResultElementResponseDto> searchResultElementResponseDtoList
                 = SearchResultElementResponseDto.listOf(searchUserTemplateList);
         return SearchResultResponseDto.of(searchResultElementResponseDtoList);
+    }
+
+    private List<SearchUserTemplate> getSearchResult(String searchText, String userId){
+        if(!Objects.equals(searchText, EMPTY_STRING))
+            return searchRepository.findAllBySearchText(searchText, userId);
+        else
+            return searchRepository.findAllByUserId(userId);
     }
 }


### PR DESCRIPTION
## 🍀 Issue

close #132 

## 🍀 Description
- 빈 스트링 검색시 전체 결과 조회
- 검색 결과 정렬 기준 적용 => mongo search score 내림차순 정렬기준 적용